### PR TITLE
Fixing code quality issues squids S2786 and S00115

### DIFF
--- a/src/main/java/org/riderzen/flume/sink/MongoSink.java
+++ b/src/main/java/org/riderzen/flume/sink/MongoSink.java
@@ -120,7 +120,7 @@ public class MongoSink extends AbstractSink implements Configurable {
             username = "";
             password = "";
         }
-        model = CollectionModel.valueOf(context.getString(MODEL, CollectionModel.single.name()));
+        model = CollectionModel.valueOf(context.getString(MODEL, CollectionModel.SINGLE.name()));
         dbName = context.getString(DB_NAME, DEFAULT_DB);
         collectionName = context.getString(COLLECTION, DEFAULT_COLLECTION);
         batchSize = context.getInteger(BATCH_SIZE, DEFAULT_BATCH);
@@ -342,11 +342,11 @@ public class MongoSink extends AbstractSink implements Configurable {
 
     private void processEvent(Map<String, List<DBObject>> eventMap, Event event) {
         switch (model) {
-            case single:
+            case SINGLE:
                 putSingleEvent(eventMap, event);
 
                 break;
-            case dynamic:
+            case DYNAMIC:
                 putDynamicEvent(eventMap, event);
 
                 break;
@@ -430,7 +430,7 @@ public class MongoSink extends AbstractSink implements Configurable {
         return documents;
     }
 
-    public static enum CollectionModel {
-        dynamic, single
+    public enum CollectionModel {
+        DYNAMIC, SINGLE
     }
 }

--- a/src/test/java/org/riderzen/flume/sink/MongoSinkTest.java
+++ b/src/test/java/org/riderzen/flume/sink/MongoSinkTest.java
@@ -61,7 +61,7 @@ public class MongoSinkTest {
 
     @Test(groups = "dev", invocationCount = 1)
     public void sinkDynamicTest() throws EventDeliveryException, InterruptedException {
-        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.dynamic.name());
+        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.DYNAMIC.name());
         MongoSink sink = new MongoSink();
         Configurables.configure(sink, ctx);
 
@@ -108,7 +108,7 @@ public class MongoSinkTest {
 
     @Test(groups = "dev")
     public void sinkDynamicTest2() throws EventDeliveryException, InterruptedException {
-        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.dynamic.name());
+        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.DYNAMIC.name());
         MongoSink sink = new MongoSink();
         Configurables.configure(sink, ctx);
 
@@ -155,7 +155,7 @@ public class MongoSinkTest {
 
     @Test(groups = "dev")
     public void sinkSingleModelTest() throws EventDeliveryException {
-        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.single.name());
+        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.SINGLE.name());
 
         MongoSink sink = new MongoSink();
         Configurables.configure(sink, ctx);
@@ -265,7 +265,7 @@ public class MongoSinkTest {
 
     @Test(groups = "dev")
     public void sinkDynamicDbTest() throws EventDeliveryException {
-        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.dynamic.name());
+        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.DYNAMIC.name());
         MongoSink sink = new MongoSink();
         Configurables.configure(sink, ctx);
 
@@ -314,7 +314,7 @@ public class MongoSinkTest {
 
     @Test(groups = "dev")
     public void timestampNewFieldTest() throws EventDeliveryException {
-        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.dynamic.name());
+        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.DYNAMIC.name());
         String tsField = "createdOn";
         ctx.put(MongoSink.TIMESTAMP_FIELD, tsField);
         MongoSink sink = new MongoSink();
@@ -366,7 +366,7 @@ public class MongoSinkTest {
 
     @Test(groups = "dev")
     public void timestampExistingFieldTest() throws EventDeliveryException, ParseException {
-        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.dynamic.name());
+        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.DYNAMIC.name());
         String tsField = "createdOn";
         ctx.put(MongoSink.TIMESTAMP_FIELD, tsField);
         MongoSink sink = new MongoSink();
@@ -422,7 +422,7 @@ public class MongoSinkTest {
 
     @Test(groups = "dev")
     public void upsertTest() throws EventDeliveryException, ParseException {
-        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.dynamic.name());
+        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.DYNAMIC.name());
         String tsField = "createdOn";
         ctx.put(MongoSink.TIMESTAMP_FIELD, tsField);
         MongoSink sink = new MongoSink();
@@ -509,7 +509,7 @@ public class MongoSinkTest {
         msg.put("_id", "111111111111111111111111111");
         msg.put("pid", "111111111111111111111111111");
 
-        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.dynamic.name());
+        ctx.put(MongoSink.MODEL, MongoSink.CollectionModel.DYNAMIC.name());
         String tsField = "createdOn";
         ctx.put(MongoSink.TIMESTAMP_FIELD, tsField);
         MongoSink sink = new MongoSink();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S2786 - “Nested "enum"s should not be declared static”. 
squid:S00115 - “Constant names should comply with a naming convention”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2786
https://dev.eclipse.org/sonar/rules/show/squid:S00115
Please let me know if you have any questions.
Ayman Abdelghany.